### PR TITLE
Add optional namespace prefix for generated modules

### DIFF
--- a/lib/compile.exprotoc.ex
+++ b/lib/compile.exprotoc.ex
@@ -33,9 +33,18 @@ defmodule Mix.Tasks.Compile.Exprotoc do
   defp get_namespace do
     namespace = Keyword.fetch Mix.project, :proto_namespace
     if namespace == :error do
-      { :ok, nil }
+      { :ok, app_name } = Keyword.fetch Mix.project, :app
+      { :ok, to_namespace(app_name) }
     else
       namespace
     end
+  end
+
+  defp to_namespace(name) do
+    name
+      |> atom_to_binary
+      |> String.split(~r{_+})
+      |> Enum.map( &(String.capitalize(&1)) )
+      |> Enum.join
   end
 end

--- a/lib/compile.exprotoc.ex
+++ b/lib/compile.exprotoc.ex
@@ -6,7 +6,8 @@ defmodule Mix.Tasks.Compile.Exprotoc do
     File.mkdir_p out_dir
     { :ok, proto_files } = Keyword.fetch Mix.project, :proto_files
     { :ok, proto_path } = get_path
-    Enum.each proto_files, &Exprotoc.compile(&1, out_dir, proto_path)
+    { :ok, proto_namespace } = get_namespace
+    Enum.each proto_files, &Exprotoc.compile(&1, out_dir, proto_path, proto_namespace)
   end
 
   defp get_out_dir do
@@ -26,6 +27,15 @@ defmodule Mix.Tasks.Compile.Exprotoc do
       { :ok, [] }
     else
       path
+    end
+  end
+
+  defp get_namespace do
+    namespace = Keyword.fetch Mix.project, :proto_namespace
+    if namespace == :error do
+      { :ok, nil }
+    else
+      namespace
     end
   end
 end

--- a/lib/exprotoc.ex
+++ b/lib/exprotoc.ex
@@ -1,8 +1,8 @@
 defmodule Exprotoc do
   import Exprotoc.Parser
   import Exprotoc.AST
-  def compile(file, out_dir, proto_path) do
+  def compile(file, out_dir, proto_path, namespace) do
     ast = file |> tokenize(proto_path) |> parse |> generate_ast(proto_path)
-    Exprotoc.Generator.generate_code ast, out_dir
+    Exprotoc.Generator.generate_code ast, out_dir, namespace
   end
 end

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -207,6 +207,9 @@ defmodule Exprotoc.Generator do
     type = type_term_to_string type_term
     if ftype == :repeated do
       acc1 = acc1 <> """
+#{i}defp put_key(msg, #{fnum}, []) do
+#{i}  msg
+#{i}end
 #{i}defp put_key(msg, #{fnum}, values) when is_list(values) do
 #{i}  HashDict.put msg, #{fnum}, { :repeated, values }
 #{i}end

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -1,8 +1,5 @@
 defmodule Exprotoc.Generator do
   @moduledoc "Given a structured AST, generate code files into an output dir."
-  
-  # prefix for module names in generated code files
-  @namespace_prefix "Proto"
 
   def generate_code({ ast, full_ast }, dir, namespace) do
     File.mkdir_p dir

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -56,6 +56,7 @@ defmodule Exprotoc.Generator do
 #{i}defmodule #{name} do
 #{i}  def decode(value), do: to_symbol value
 #{i}  def to_a({ #{fullname}, atom }), do: atom
+#{i}  def from_a( atom ), do: { #{fullname}, atom }
 #{enum_funs}#{i}end
 """
   end

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -55,6 +55,7 @@ defmodule Exprotoc.Generator do
     """
 #{i}defmodule #{name} do
 #{i}  def decode(value), do: to_symbol value
+#{i}  def to_a({ #{fullname}, atom }), do: atom
 #{enum_funs}#{i}end
 """
   end

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -179,7 +179,12 @@ defmodule Exprotoc.Generator do
   end
   defp process_fields(ast, scope, fields, level, namespace) do
     i = indent level + 1
-    acc = { "", "", "", "", "", [] , ""}
+    ftype_acc = """
+#{i}def get_ftype(-1), do: :required
+#{i}def get_ftype(-2), do: :repeated
+#{i}def get_ftype(-3), do: :optional
+"""
+    acc = { "", "", ftype_acc, "", "", [] , ""}
     { acc1, acc2, acc3, acc4, acc5, acc6, acc7 } =
       List.foldl fields, acc,
            &process_field(ast, scope, &1, &2, i, namespace)

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -1,14 +1,17 @@
 defmodule Exprotoc.Generator do
   @moduledoc "Given a structured AST, generate code files into an output dir."
+  
+  # prefix for module names in generated code files
+  @namespace_prefix "Proto"
 
-  def generate_code({ ast, full_ast }, dir) do
+  def generate_code({ ast, full_ast }, dir, namespace) do
     File.mkdir_p dir
-    generate_modules { [], full_ast }, [], HashDict.to_list(ast), dir
+    generate_modules { [], full_ast }, [], HashDict.to_list(ast), dir, namespace
   end
-  def generate_code({ package, ast, full_ast}, dir) do
+  def generate_code({ package, ast, full_ast}, dir, namespace) do
     dir = create_package_dir package, dir
     { [], ast } = ast[package]
-    generate_modules { [], full_ast }, [package], HashDict.to_list(ast), dir
+    generate_modules { [], full_ast }, [package], HashDict.to_list(ast), dir, namespace
   end
 
   defp create_package_dir(package, dir) do
@@ -18,20 +21,20 @@ defmodule Exprotoc.Generator do
     dir
   end
 
-  defp generate_modules(_, _, [], _) do end
-  defp generate_modules(ast, scope, [module|modules], dir) do
+  defp generate_modules(_, _, [], _, _) do end
+  defp generate_modules(ast, scope, [module|modules], dir, namespace) do
     { name, _ } = module
     new_scope = [ name | scope ]
     module_filename = name |> atom_to_binary |> to_module_filename
     path = Path.join dir, module_filename
     IO.puts "Generating #{module_filename}"
-    module_text = generate_module ast, new_scope, module, 0, false
+    module_text = generate_module ast, new_scope, module, 0, false, namespace
     File.write path, module_text
-    generate_modules ast, scope, modules, dir
+    generate_modules ast, scope, modules, dir, namespace
   end
 
-  defp generate_module(_, scope, { _, { :enum, enum_values } }, level, sub) do
-    fullname = scope |> Enum.reverse |> get_module_name
+  defp generate_module(_, scope, { _, { :enum, enum_values } }, level, sub, namespace) do
+    fullname = scope |> Enum.reverse |> get_module_name(namespace)
     if sub do
       [name|_] = scope
       name = atom_to_binary name
@@ -58,20 +61,20 @@ defmodule Exprotoc.Generator do
 #{enum_funs}#{i}end
 """
   end
-  defp generate_module(ast, scope, module, level, sub) do
+  defp generate_module(ast, scope, module, level, sub, namespace) do
     if sub do
       [name|_] = scope
       name = atom_to_binary name
     else
-      name = scope |> Enum.reverse |> get_module_name
+      name = scope |> Enum.reverse |> get_module_name(namespace)
     end
     i = indent level
-    fields_text = process_fields ast, scope, module, level
+    fields_text = process_fields ast, scope, module, level, namespace
     submodules = module |> elem(1) |> elem(1) |> HashDict.to_list
     submodule_text = List.foldl submodules, "",
                           fn(m = { n, _ }, acc) ->
                               acc <> generate_module(ast, [n|scope],
-                                                     m, level + 1, true)
+                                                     m, level + 1, true, namespace)
                           end
 
     """
@@ -149,19 +152,26 @@ defmodule Exprotoc.Generator do
 """
   end
 
-  def get_module_name(names) do
-    Enum.join names, "."
+  def get_module_name(names, namespace) do
+    prepend_namespace(names, namespace) |> Enum.join "."
   end
 
-  defp process_fields(ast, scope, { _, { fields, _ } }, level) do
-    process_fields ast, scope, fields, level
+  def prepend_namespace(names, nil) do
+    names
   end
-  defp process_fields(ast, scope, fields, level) do
+  def prepend_namespace(names, namespace) do
+    [namespace|names]
+  end
+
+  defp process_fields(ast, scope, { _, { fields, _ } }, level, namespace) do
+    process_fields ast, scope, fields, level, namespace
+  end
+  defp process_fields(ast, scope, fields, level, namespace) do
     i = indent level + 1
     acc = { "", "", "", "", "", [] }
     { acc1, acc2, acc3, acc4, acc5, acc6 } =
       List.foldl fields, acc,
-           &process_field(ast, scope, &1, &2, i)
+           &process_field(ast, scope, &1, &2, i, namespace)
     acc5 = acc5 <> "#{i}def get_default(_), do: nil\n"
     key_string = generate_keystring acc6, i
     acc1 <> acc2 <> acc3 <> acc4 <> acc5 <> key_string
@@ -176,8 +186,8 @@ defmodule Exprotoc.Generator do
   end
 
   defp process_field(ast, scope, { :field, ftype, type, name, fnum, opts },
-                     { acc1, acc2, acc3, acc4, acc5, acc6 } , i) do
-    type = type_to_string ast, scope, type
+                     { acc1, acc2, acc3, acc4, acc5, acc6 } , i, namespace) do
+    type = type_to_string ast, scope, type, namespace
     if ftype == :repeated do
       acc1 = acc1 <> """
 #{i}defp put_key(msg, #{fnum}, values) when is_list(values) do
@@ -202,17 +212,17 @@ defmodule Exprotoc.Generator do
 
   defp indent(level), do: String.duplicate("  ", level)
 
-  defp type_to_string(ast, scope, type) when is_list(type) do
+  defp type_to_string(ast, scope, type, namespace) when is_list(type) do
     { module, pointer } = Exprotoc.AST.search_ast ast, scope, type
     if elem(module, 0) == :enum do
-      "{ :enum, " <> get_module_name(pointer) <> " }"
+      "{ :enum, " <> get_module_name(pointer, namespace) <> " }"
     else
-      "{ :message, " <> get_module_name(pointer) <> " }"
+      "{ :message, " <> get_module_name(pointer, namespace) <> " }"
     end
   end
-  defp type_to_string(ast, scope, type) do
+  defp type_to_string(ast, scope, type, namespace) do
     if Exprotoc.Protocol.wire_type(type) == :custom do
-      type_to_string ast, scope, [type]
+      type_to_string ast, scope, [type], namespace
     else
       ":" <> atom_to_binary(type)
     end

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -149,6 +149,10 @@ defmodule Exprotoc.Generator do
 
 #{fields_text}#{submodule_text}#{i}end
 
+#{i}defimpl Inspect, for: #{name}.T do
+#{i}  def inspect(msg, opts), do: Exprotoc.Inspect.inspect(#{name}, msg, opts)
+#{i}end
+
 #{i}defimpl Access, for: #{name}.T do
 #{i}  def access(msg, key), do: #{name}.get(msg, key)
 #{i}end
@@ -175,13 +179,13 @@ defmodule Exprotoc.Generator do
   end
   defp process_fields(ast, scope, fields, level, namespace) do
     i = indent level + 1
-    acc = { "", "", "", "", "", [] }
-    { acc1, acc2, acc3, acc4, acc5, acc6 } =
+    acc = { "", "", "", "", "", [] , ""}
+    { acc1, acc2, acc3, acc4, acc5, acc6, acc7 } =
       List.foldl fields, acc,
            &process_field(ast, scope, &1, &2, i, namespace)
     acc5 = acc5 <> "#{i}def get_default(_), do: nil\n"
     key_string = generate_keystring acc6, i
-    acc1 <> acc2 <> acc3 <> acc4 <> acc5 <> key_string
+    acc1 <> acc2 <> acc7 <>  acc3 <> acc4 <> acc5 <> key_string
   end
 
   defp generate_keystring(keys, i) do
@@ -193,7 +197,7 @@ defmodule Exprotoc.Generator do
   end
 
   defp process_field(ast, scope, { :field, ftype, type, name, fnum, opts } = arg,
-                     { acc1, acc2, acc3, acc4, acc5, acc6 } , i, namespace) do
+                     { acc1, acc2, acc3, acc4, acc5, acc6, acc7 } , i, namespace) do
     type_term = type_to_term ast, scope, type, namespace
     type = type_term_to_string type_term
     if ftype == :repeated do
@@ -213,7 +217,8 @@ defmodule Exprotoc.Generator do
     acc3 = acc3 <> "#{i}def get_ftype(#{fnum}), do: :#{ftype}\n"
     acc4 = acc4 <> "#{i}def get_type(#{fnum}), do: #{type}\n"
     acc5 = acc5 <> generate_default_value(i, fnum, type_term, opts)
-    { acc1, acc2, acc3, acc4, acc5, [ name | acc6 ] }
+    acc7 = acc7 <> "#{i}def get_fname(#{fnum}), do: :#{name}\n"
+    { acc1, acc2, acc3, acc4, acc5, [ name | acc6 ], acc7}
   end
 
   defp generate_default_value(i, fnum, type, opts) do

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -235,8 +235,8 @@ defmodule Exprotoc.Generator do
   end
 
   defp to_enum_type(name) do
-    name = atom_to_binary name
-    name = Regex.replace ~r/([A-Z])/, name, "_\\1"
-    name |> String.lstrip(?_) |> String.downcase
+    name
+      |> atom_to_binary
+      |> String.downcase
   end
 end

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -114,7 +114,10 @@ defmodule Exprotoc.Generator do
 #{i}      put acc, k, v
 #{i}    end
 #{i}  end
-#{i}  def get(msg, key) do
+#{i}  def get(msg, keys) when is_list(keys) do
+#{i}    Enum.map keys, &( get(msg, &1) )
+#{i}  end
+#{i}  def get(msg, key) when is_atom(key) do
 #{i}    f_num = get_fnum key
 #{i}    m = msg.message
 #{i}    if HashDict.has_key?(m, f_num) do

--- a/lib/exprotoc/generator.ex
+++ b/lib/exprotoc/generator.ex
@@ -150,7 +150,11 @@ defmodule Exprotoc.Generator do
   end
 
   def get_module_name(names, namespace) do
-    prepend_namespace(names, namespace) |> Enum.join "."
+    prepend_namespace(names, namespace) |> get_module_name
+  end
+
+  def get_module_name(names) do
+    Enum.join names, "."
   end
 
   def prepend_namespace(names, nil) do

--- a/lib/exprotoc/inspect.ex
+++ b/lib/exprotoc/inspect.ex
@@ -1,0 +1,31 @@
+defmodule Exprotoc.Inspect do
+  import Inspect.Algebra
+
+  def inspect(module, msg, opts) do
+    concat [to_doc(module, opts), "[",
+            to_doc(msg.message, opts),
+    #Enum.reduce(msg.message, empty,
+    #            fn({k, v}, acc) ->
+    #                inspect_field(module, k, v, acc, opts)
+    #            end),
+         "]"
+           ]
+  end
+
+  def inspect_field(module, k, v, acc, opts) do
+    name = module.get_fname(k)
+    field = concat [
+                    to_doc(name, opts),
+                    "(",
+                    to_doc(k, opts),
+                    ")",
+                    " ",
+                    to_doc(v, opts)
+              ]
+    if empty == acc do
+      field
+    else
+      glue(field, ", ", acc)
+    end
+  end
+end

--- a/lib/exprotoc/message.ex
+++ b/lib/exprotoc/message.ex
@@ -1,3 +1,3 @@
 defmodule Exprotoc.Message do
-  @type t :: Dict.t
+  @type t :: {module, Dict.t}
 end

--- a/lib/exprotoc/parser.ex
+++ b/lib/exprotoc/parser.ex
@@ -13,7 +13,7 @@ defmodule Exprotoc.Parser do
     { :ok, tokens, _ } = :erl_scan.string(list_text, 1,
                                           { :reserved_word_fun ,
                                             &reserved_words/1 })
-    tokens
+    {file, tokens}
   end
 
   def find_file(file, []) do
@@ -32,9 +32,13 @@ defmodule Exprotoc.Parser do
     end
   end
 
-  def parse(tokens) do
-    { :ok, ast } = :proto_grammar.parse tokens
-    ast
+  def parse({file, tokens}) do
+    case :proto_grammar.parse tokens do
+      { :ok, ast } ->
+        ast
+      error ->
+        raise "parse error in #{file}: #{inspect(error)}"
+    end
   end
 
   defp reserved_words(:package), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -4,14 +4,16 @@ defmodule Exprotoc.Mixfile do
   def project do
     [ app: :exprotoc,
       version: "0.0.1",
-      elixir: "~> 0.12.5",
+      elixir: ">= 0.12.5",
       compilers: [ :yecc, :erlang, :elixir, :app ],
       deps: deps ]
   end
 
   # Configuration for the OTP application
   def application do
-    []
+    [
+     env: [prefix: "Proto"]
+    ]
   end
 
   # Returns the list of dependencies in the format:

--- a/test/test_wrapper/mix.exs
+++ b/test/test_wrapper/mix.exs
@@ -4,13 +4,14 @@ defmodule TestWrapper.Mixfile do
   def project do
     [ app: :test_wrapper,
       version: "0.0.1",
-      elixir: "~> 0.12.5",
+      elixir: ">= 0.12.5",
       compilers: [:exprotoc, :elixir, :app],
       proto_files: ["nopackage.proto",
                     "test.proto",
                     "other.proto",
                     "another.proto"],
       proto_path: ["priv"],
+      proto_namespace: "Proto",
       deps: deps ]
   end
 

--- a/test/test_wrapper/priv/test.proto
+++ b/test/test_wrapper/priv/test.proto
@@ -10,8 +10,9 @@ message Test1 {
 message Test2 {
   enum Foo {
     Bar = 150;
+    Baz = 160;
   }
-  required Foo b = 1;
+  required Foo b = 1 [default = Baz];
 }
 
 message Test3 {

--- a/test/test_wrapper/test/test_wrapper_test.exs
+++ b/test/test_wrapper/test/test_wrapper_test.exs
@@ -2,182 +2,182 @@ defmodule TestWrapperTest do
   use ExUnit.Case
 
   test "access uint32" do
-    t = Test.Test1.new a: 3
+    t = Proto.Test.Test1.new a: 3
     assert t[:a] == 3
-    t = Test.Test1.put t, :a, 4
+    t = Proto.Test.Test1.put t, :a, 4
     assert t[:a] == 4
   end
 
   test "encode uint32" do
-    t = Test.Test1.new a: 150
-    p = t |> Test.Test1.encode |> iolist_to_binary
+    t = Proto.Test.Test1.new a: 150
+    p = t |> Proto.Test.Test1.encode |> iolist_to_binary
     assert p == << 8, 150, 1 >>
   end
 
   test "decode uint32" do
-    t = Test.Test1.decode << 8, 150, 1 >>
+    t = Proto.Test.Test1.decode << 8, 150, 1 >>
     assert t[:a] == 150
   end
 
   test "encode enum" do
-    t = Test.Test2.new b: Test.Test2.Foo.bar
-    assert t[:b] == Test.Test2.Foo.bar
-    payload = t |> Test.Test2.encode |> iolist_to_binary
+    t = Proto.Test.Test2.new b: Proto.Test.Test2.Foo.bar
+    assert t[:b] == Proto.Test.Test2.Foo.bar
+    payload = t |> Proto.Test.Test2.encode |> iolist_to_binary
     assert payload == << 8, 150, 1 >>
   end
 
   test "decode enum" do
     payload = << 8, 150, 1>>
-    message = Test.Test2.decode payload
-    assert message[:b] == { Test.Test2.Foo, :bar }
+    message = Proto.Test.Test2.decode payload
+    assert message[:b] == { Proto.Test.Test2.Foo, :bar }
   end
 
   test "encode nested message" do
-    inner = Test.Test1.new a: 150
-    outer = Test.Test3.new c: inner
+    inner = Proto.Test.Test1.new a: 150
+    outer = Proto.Test.Test3.new c: inner
     assert outer[:c][:a] == 150
-    payload = outer |> Test.Test3.encode |> iolist_to_binary
+    payload = outer |> Proto.Test.Test3.encode |> iolist_to_binary
     assert payload == << 26, 3, 8, 150, 1 >>
   end
 
   test "decode nested message" do
     payload = << 26, 3, 8, 150, 1 >>
-    message = Test.Test3.decode payload
+    message = Proto.Test.Test3.decode payload
     assert message[:c][:a] == 150
   end
 
   test "encode repeated message" do
-    message = Test.Test4.new d: [250, 150]
+    message = Proto.Test.Test4.new d: [250, 150]
     assert message[:d] == [250, 150]
-    payload = message |> Test.Test4.encode |> iolist_to_binary
+    payload = message |> Proto.Test.Test4.encode |> iolist_to_binary
     assert payload == << 8, 250, 1, 8, 150, 1 >>
   end
 
   test "decode repeated message" do
     payload = << 8, 250, 1, 8, 150, 1 >>
-    message = Test.Test4.decode payload
+    message = Proto.Test.Test4.decode payload
     assert message[:d] == [250, 150]
   end
 
   test "encode nested repeated messages" do
-    m1 = Test.Test5.Test6.new f: 150
-    m2 = Test.Test5.Test6.new f: 300
-    message = Test.Test5.new e: [m1, m2]
-    payload = message |> Test.Test5.encode |> iolist_to_binary
+    m1 = Proto.Test.Test5.Test6.new f: 150
+    m2 = Proto.Test.Test5.Test6.new f: 300
+    message = Proto.Test.Test5.new e: [m1, m2]
+    payload = message |> Proto.Test.Test5.encode |> iolist_to_binary
     assert payload == << 10, 3, 8, 150, 1, 10, 3, 8, 172, 2 >>
   end
 
   test "decode nested repeated messages" do
     payload = << 10, 3, 8, 150, 1, 10, 3, 8, 172, 2 >>
-    message = Test.Test5.decode payload
+    message = Proto.Test.Test5.decode payload
     [m1, m2] = message[:e]
     assert m1[:f] == 150
     assert m2[:f] == 300
   end
 
   test "encode bool" do
-    message = Test.Test7.new g: true
+    message = Proto.Test.Test7.new g: true
     assert message[:g] == true
-    payload = message |> Test.Test7.encode |> iolist_to_binary
+    payload = message |> Proto.Test.Test7.encode |> iolist_to_binary
     assert payload == << 8, 1 >>
   end
 
   test "decode bool" do
     payload = << 8, 1 >>
-    message = Test.Test7.decode payload
+    message = Proto.Test.Test7.decode payload
     assert message[:g] == true
     payload = << 8, 0 >>
-    message = Test.Test7.decode payload
+    message = Proto.Test.Test7.decode payload
     assert message[:g] == false
   end
 
   test "encode external enum" do
-    message = Test.Test9.new j: Test.Test2.Foo.bar
-    assert message[:j] == { Test.Test2.Foo, :bar }
-    payload = message |> Test.Test9.encode |> iolist_to_binary
+    message = Proto.Test.Test9.new j: Proto.Test.Test2.Foo.bar
+    assert message[:j] == { Proto.Test.Test2.Foo, :bar }
+    payload = message |> Proto.Test.Test9.encode |> iolist_to_binary
     assert payload == << 8, 150, 1 >>
   end
 
   test "decode external enum" do
     payload = << 8, 150, 1 >>
-    message = Test.Test9.decode payload
-    assert message[:j] == { Test.Test2.Foo, :bar }
+    message = Proto.Test.Test9.decode payload
+    assert message[:j] == { Proto.Test.Test2.Foo, :bar }
   end
 
   test "encode external message" do
-    m = Test.Test5.Test6.new f: 150
-    message = Test.Test10.new k: m
+    m = Proto.Test.Test5.Test6.new f: 150
+    message = Proto.Test.Test10.new k: m
     assert message[:k][:f] == 150
-    payload = message |> Test.Test10.encode |> iolist_to_binary
+    payload = message |> Proto.Test.Test10.encode |> iolist_to_binary
     assert payload == << 10, 3, 8, 150, 1 >>
   end
 
   test "decode external message" do
     payload = << 10, 3, 8, 150, 1 >>
-    message = Test.Test10.decode payload
+    message = Proto.Test.Test10.decode payload
     assert message[:k][:f] == 150
   end
 
   test "incode imported message" do
-    m = Other.Msg1.new a: 150
-    message = Test.Test11.new l: m
+    m = Proto.Other.Msg1.new a: 150
+    message = Proto.Test.Test11.new l: m
     assert message[:l][:a] == 150
-    payload = message |> Test.Test11.encode |> iolist_to_binary
+    payload = message |> Proto.Test.Test11.encode |> iolist_to_binary
     assert payload == << 10, 3, 8, 150, 1 >>
   end
 
   test "decode imported message" do
     payload = << 10, 3, 8, 150, 1>>
-    message = Test.Test11.decode payload
+    message = Proto.Test.Test11.decode payload
     assert message[:l][:a] == 150
   end
 
   test "encode nested imported message" do
-    m = Other.Msg1.Msg3.new b: 150
-    message = Test.Test12.new m: m
+    m = Proto.Other.Msg1.Msg3.new b: 150
+    message = Proto.Test.Test12.new m: m
     assert message[:m][:b] == 150
-    payload = message |> Test.Test12.encode |> iolist_to_binary
+    payload = message |> Proto.Test.Test12.encode |> iolist_to_binary
     assert payload == << 10, 3, 8, 150, 1 >>
   end
 
   test "decode nested imported message" do
     payload = << 10, 3, 8, 150, 1>>
-    message = Test.Test12.decode payload
+    message = Proto.Test.Test12.decode payload
     assert message[:m][:b] == 150
   end
 
   test "missing package header" do
-    message = NoPackage.new a: 150
+    message = Proto.NoPackage.new a: 150
     assert message[:a] == 150
-    payload = message |> NoPackage.encode |> iolist_to_binary
+    payload = message |> Proto.NoPackage.encode |> iolist_to_binary
     assert payload == << 8, 150, 1 >>
-    message = NoPackage.decode payload
+    message = Proto.NoPackage.decode payload
     assert message[:a] == 150
   end
 
   test "access field with default" do
-    message = Test.Test7.new
+    message = Proto.Test.Test7.new
     assert message[:g] == true
   end
 
   test "encode field with defaults" do
-    message = Test.Test13.new
+    message = Proto.Test.Test13.new
     assert message[:n] == 150
     assert message[:o] == 300
-    payload = message |> Test.Test13.encode |> iolist_to_binary
+    payload = message |> Proto.Test.Test13.encode |> iolist_to_binary
     assert payload == << 8, 150, 1, 16, 172, 2 >>
   end
 
   test "decode field with defaults" do
     payload = <<>>
-    message = Test.Test13.decode payload
+    message = Proto.Test.Test13.decode payload
     assert message[:n] == 150
     assert message[:o] == 300
   end
 
   test "copy existing message" do
-    message = Test.Test13.new n: 100
-    copy = Test.Test13.new message, o: 200
+    message = Proto.Test.Test13.new n: 100
+    copy = Proto.Test.Test13.new message, o: 200
     assert copy[:n] == 100
     assert copy[:o] == 200
   end

--- a/test/test_wrapper/test/test_wrapper_test.exs
+++ b/test/test_wrapper/test/test_wrapper_test.exs
@@ -30,6 +30,7 @@ defmodule TestWrapperTest do
     payload = << 8, 150, 1>>
     message = Proto.Test.Test2.decode payload
     assert message[:b] == { Proto.Test.Test2.Foo, :bar }
+    assert Proto.Test.Test2.Foo.to_a(message[:b]) == :bar
   end
 
   test "encode nested message" do

--- a/test/test_wrapper/test/test_wrapper_test.exs
+++ b/test/test_wrapper/test/test_wrapper_test.exs
@@ -182,4 +182,9 @@ defmodule TestWrapperTest do
     assert copy[:n] == 100
     assert copy[:o] == 200
   end
+
+  test "multi get" do
+    m = Proto.Test.Test13.new n: 100, o: 200
+    assert [200, 100] == Proto.Test.Test13.get(m, [:o, :n])
+  end
 end


### PR DESCRIPTION
the optional `proto_namespace` parameter will be prepended to all generated module names
