### PR TITLE
Update Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Exprotoc.Mixfile do
   def project do
     [ app: :exprotoc,
       version: "0.0.1",
-      elixir: "~> 0.12.5",
+      elixir: "~> 0.13.0",
       compilers: [ :yecc, :erlang, :elixir, :app ],
       deps: deps ]
   end


### PR DESCRIPTION
Make this usable in projects using Elixir 0.13.0 or greater. Probably needs tags for pre and post merge too, since it will make it unusable for projects running off of master and on 0.12.5.
